### PR TITLE
fix: do not forget leading zeroes when decoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ erl_crash.dump
 *.ez
 *.beam
 /config/*.secret.exs
+*.swp

--- a/lib/base58.ex
+++ b/lib/base58.ex
@@ -37,16 +37,21 @@ defmodule Base58 do
   def decode(""), do: "" # return empty string unmodified
   def decode("\0"), do: "" # treat null values as empty
   def decode(binary) do
-    # avoid dropping leading zeros -- see https://github.com/dwyl/base58/issues/27
-    origlen = String.length(binary)
-    binary = String.trim_leading(binary, "1")
-    newlen = String.length(binary)
-    String.duplicate(<<0>>, origlen - newlen) <> decode(binary, 0)
+    {zeroes, binary} = handle_leading_zeroes(binary)
+    zeroes <> decode(binary, 0)
   end
   def decode("", 0), do: ""
   def decode("", acc), do: :binary.encode_unsigned(acc)
   def decode(<<head, tail::binary>>, acc),
     do: decode(tail, acc * 58 + Enum.find_index(@alnum, &(&1 == head)))
+
+  def handle_leading_zeroes(binary) do
+    # avoid dropping leading zeros -- see https://github.com/dwyl/base58/issues/27
+    origlen = String.length(binary)
+    binary = String.trim_leading(binary, <<List.first(@alnum)>>)
+    newlen = String.length(binary)
+    {String.duplicate(<<0>>, origlen - newlen), binary}
+  end
 
   @doc """
   `decode_to_int/1` decodes the given Base58 string back to an Integer.

--- a/lib/base58.ex
+++ b/lib/base58.ex
@@ -45,7 +45,7 @@ defmodule Base58 do
   def decode(<<head, tail::binary>>, acc),
     do: decode(tail, acc * 58 + Enum.find_index(@alnum, &(&1 == head)))
 
-  def handle_leading_zeroes(binary) do
+  defp handle_leading_zeroes(binary) do
     # avoid dropping leading zeros -- see https://github.com/dwyl/base58/issues/27
     origlen = String.length(binary)
     binary = String.trim_leading(binary, <<List.first(@alnum)>>)

--- a/lib/base58.ex
+++ b/lib/base58.ex
@@ -36,7 +36,14 @@ defmodule Base58 do
 
   def decode(""), do: "" # return empty string unmodified
   def decode("\0"), do: "" # treat null values as empty
-  def decode(binary), do: decode(binary, 0)
+  def decode(binary) do
+    # avoid dropping leading zeros -- see https://github.com/dwyl/base58/issues/27
+    origlen = String.length(binary)
+    binary = String.trim_leading(binary, "1")
+    newlen = String.length(binary)
+    String.duplicate(<<0>>, origlen - newlen) <> decode(binary, 0)
+  end
+  def decode("", 0), do: ""
   def decode("", acc), do: :binary.encode_unsigned(acc)
   def decode(<<head, tail::binary>>, acc),
     do: decode(tail, acc * 58 + Enum.find_index(@alnum, &(&1 == head)))

--- a/test/base58_test.exs
+++ b/test/base58_test.exs
@@ -61,6 +61,14 @@ defmodule Base58Test do
       assert decoded == int
     end
 
+    test "decode 11111 returns <<0, 0, 0, 0, 0>>" do
+      assert <<0, 0, 0, 0, 0>> == decode("11111")
+    end
+
+    test "decode 11112 returns <<0, 0, 0, 0, 1>>" do
+      assert <<0, 0, 0, 0, 1>> == decode("11112")
+    end
+
     property "Check a batch of int values can be decoded" do
       check all(int <- integer()) do
         assert decode_to_int(encode(int)) == int


### PR DESCRIPTION
Solution to #27. Included a few tests and it worked. Inspired by [this](https://github.com/keis/base58/blob/master/base58/__init__.py#L131).